### PR TITLE
Frings-保研经验贴上篇链接增加

### DIFF
--- a/docs/保研经验贴/2024年保研总结贴/index.md
+++ b/docs/保研经验贴/2024年保研总结贴/index.md
@@ -19,3 +19,4 @@
 * @[Fsamuellll](https://www.zhihu.com/people/fsamuel)的[25届计算机保研经验分享（10天梦幻保研旅程）](https://zhuanlan.zhihu.com/p/708507301)
 * @[LawnJerch](https://github.com/Alter-Liu)的[2025届计算机保研流水账 | 低rank有科研有实习（西湖大学、计算所、贵系工程硕博）](https://zhuanlan.zhihu.com/p/796755384)
 * @[合金Bunny酱](https://space.bilibili.com/305821778)的[2024计算机保研经验贴（哈工深，中山，华工，东南）](https://www.bilibili.com/opus/982457937753538582)
+* @[Frings](https://www.zhihu.com/people/lin-dong-jiang-zhi-91-76)的[2024计算机保研经验贴上-夏令营篇-清叉北智软微人大高瓴清深TBSI复旦CS科大CS](https://zhuanlan.zhihu.com/p/774165680)


### PR DESCRIPTION
在docs/保研经验贴/2024年保研总结贴/index.md中添加了Frings的知乎个人主页和保研经验贴上篇的链接